### PR TITLE
Adding quiet-askpass to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN set -x                                                               && \
     make && make install                                                 && \
     cd / && rm -rf /lastpass-cli-${VER}
 
+ADD bin/bash-askpass /usr/local/bin/bash-askpass
+
 VOLUME /root/.lpass
 
 ENTRYPOINT ["/usr/bin/lpass"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x                                                               && \
     cd / && rm -rf /lastpass-cli-${VER}
 
 ADD bin/bash-askpass /usr/local/bin/bash-askpass
+ADD bin/quiet-askpass /usr/local/bin/quiet-askpass
 
 VOLUME /root/.lpass
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Usage
 
     docker run --rm -it -v ~/.lpass:/root/.lpass returnpath/lpass
+
+# Askpass Scripts
+
+This container has a couple helper scripts for prompting for the master password:
+
+ - `bin/bash-askpass`: Pass in a string for the prompt text to show, then it will read in your master password and echo it to STDOUT.  This will be piped directly into `lpass` when used as `LPASS_ASKPASS`.
+ - `bin/quiet-askpass`: Same as `bash-askpass` but without the prompt.
+
+To use either of the included `askpass` scripts, simply set `LPASS_ASKPASS` to the script name.  For example:
+
+    # Prompts with: "Enter LastPass Master Password: "
+    docker run --rm -it -v ~/.lpass:/root/.lpass returnpath/lpass  -e LPASS_ASKPASS='bash-askpass Enter LastPass Master Password'
+    # Without prompt
+    docker run --rm -it -v ~/.lpass:/root/.lpass returnpath/lpass  -e LPASS_ASKPASS=quiet-askpass
+
+For more advanced usage, see the [Official `lpass` man page][1]
+
+[1]: https://lastpass.github.io/lastpass-cli/lpass.1.html

--- a/bin/bash-askpass
+++ b/bin/bash-askpass
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo -n "$*: " >/dev/stderr
+stty -echo
+read answer
+stty echo
+echo $answer

--- a/bin/quiet-askpass
+++ b/bin/quiet-askpass
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo -n "$*: " >/dev/null
+stty -echo
+read answer
+stty echo
+echo $answer


### PR DESCRIPTION
[Helper script][1] to use with `lpass` for quiet password entry.

 - To use, set: `LPASS_ASKPASS='quiet-askpass'`
 - With `docker run`: `-e LPASS_ASKPASS='quiet-askpass'`

[1]: https://lastpass.github.io/lastpass-cli/lpass.1.html#_password_entry