### PR TITLE
Adding gettext-base / envsubst to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN set -x                                                             && \
                        libxml2-dev pinentry-curses curl make unzip     && \
     apt-get clean
 
+RUN apt-get install -y gettext-base
+
 ENV VER 0.8.1
 
 RUN set -x                                                               && \


### PR DESCRIPTION
We need this to run inside the lpass container for scripts that need `envsubst`.

This is part of: [ReturnPath/kubernetes-jobs@5edca51][1]

[1]: https://github.com/ReturnPath/efp-kubernetes-jobs/commit/5edca515255764542648ccd0c9cf5521a2075edc