### PR TITLE
AS-3715: Force use of GNU awk for special "|&" coprocess syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x                                                             && \
                        libxml2-dev pinentry-curses curl make unzip     && \
     apt-get clean
 
-RUN apt-get install -y gettext-base
+RUN apt-get install -y gettext-base gawk
 
 ENV VER 0.8.1
 


### PR DESCRIPTION
awk inside the container is actually `mawk`, which does not support piping to coprocess.

We need [GNU awk (`gawk`) for this to work][1]...

[1]: http://www.gnu.org/software/gawk/manual/html_node/Two_002dway-I_002fO.html#Two_002dway-I_002fO